### PR TITLE
Fix spelling and typo

### DIFF
--- a/proposals/servo-webgpu.md
+++ b/proposals/servo-webgpu.md
@@ -6,7 +6,7 @@
 ## Project Description 
 
 There is a an initial implementation of WebGPU in Servo.
-This GSoC proposal is for improving this to a point where basic examples can be ran, and a fair portion of the conformance test suit is covered.
+This GSoC proposal is for improving this to a point where basic examples can be ran, and a fair portion of the conformance test suite is covered.
 
 ## Skills Required
 
@@ -20,7 +20,7 @@ Prior experience working with Servo or wgpu-rs is a plus.
 
 ## Project Details
 
-[WebGPU](https://gpuweb.github.io/gpuweb/) is an emerging API or the Web that efficiently exposes graphics and compute capabilities. It's not based on an existing native API but is inspired by, and targeting Vulkan, D3D12, and Vulkan.
+[WebGPU](https://gpuweb.github.io/gpuweb/) is an emerging API or the Web that efficiently exposes graphics and compute capabilities. It's not based on an existing native API but is inspired by, and targeting Vulkan, D3D12, and Metal.
 
 [Servo](https://github.com/servo/servo/) is an experimental browser engine written in [Rust](https://www.rust-lang.org/) language. It was an early home for [Stylo](https://hacks.mozilla.org/2017/08/inside-a-super-fast-css-engine-quantum-css-aka-stylo/) and [WebRender](https://hacks.mozilla.org/2017/10/the-whole-web-at-maximum-fps-how-webrender-gets-rid-of-jank/), which are now parts of Firefox. Servo is currently used to experiment with VR/AR applications, where latency, power consumption, and performance requirements are extremely tight. Therefore, implementing WebGPU in Servo opens the doors for more immersive experience in VR and AR.
 


### PR DESCRIPTION
I assumed the third native API targeted by WebGPU is Metal, and not Vulkan a second time!